### PR TITLE
Add buffs persistence

### DIFF
--- a/LunarApostles/LunarApostles.cs
+++ b/LunarApostles/LunarApostles.cs
@@ -101,10 +101,10 @@ namespace LunarApostles
         // 308 -139 398 525.0092 -156.221 603.6622
         SetPosition(new Vector3(308, -139, 398), self);
         completedPillar = false;
+        LoadPersistentBuffs(self);
       }
 
-      bool anyPillarActivated = activatedMass || activatedDesign || activatedBlood || activatedSoul;
-      if (anyPillarActivated && (sceneName == "moon2" || sceneName == "limbo"))
+      if (sceneName == "limbo" && (activatedMass || activatedDesign || activatedBlood || activatedSoul))
         LoadPersistentBuffs(self);
     }
 


### PR DESCRIPTION
E8 Curse and Bandit's Desperado Stacks now persists between `moon2` and `limbo` stages.

I already have some ideas on how to make the transition even more seamless (saving stage RNG, respawning next to the pillar, etc.), but buffs persistence is already working, so why not PR it.